### PR TITLE
client: Offline usage support

### DIFF
--- a/account.go
+++ b/account.go
@@ -327,6 +327,12 @@ func parseShare(r io.Reader, encryptionKey []byte, privateKey *rsa.PrivateKey) (
 	} else {
 		// The user who shares the folder with us, encrypted the sharing key with our public key.
 		// Therefore, we decrypt the sharing key with our private key.
+		if privateKey == nil {
+			return share{}, errors.New("account private key is nil - " +
+				"refer to the following url for more information: " +
+				"https://support.lastpass.com/help/" +
+				"why-am-i-seeing-an-error-no-private-key-cannot-decrypt-pending-shares-message-lp010147")
+		}
 
 		sharingKeyRSAEncrypted, err := decodeHex(sharingKeyRSAEncryptedHex)
 		if err != nil {

--- a/account.go
+++ b/account.go
@@ -162,7 +162,7 @@ func (c *Client) parseBlob(r io.Reader) ([]*Account, error) {
 			share, err = parseShare(
 				bytes.NewReader(chunk.payload),
 				c.session.EncryptionKey,
-				c.session.PrivateKey)
+				c.session.OptSharingKey)
 			if err != nil {
 				return nil, err
 			}
@@ -411,7 +411,7 @@ func (c *Client) getShare(ctx context.Context, shareName string) (share, error) 
 			share, err := parseShare(
 				bytes.NewReader(chunk.payload),
 				c.session.EncryptionKey,
-				c.session.PrivateKey)
+				c.session.OptSharingKey)
 			if err != nil {
 				return share, err
 			}

--- a/account.go
+++ b/account.go
@@ -124,7 +124,7 @@ func (c *Client) parseBlob(r io.Reader) ([]*Account, error) {
 	}
 
 	accts := make([]*Account, 0)
-	key := c.session.encryptionKey
+	key := c.session.EncryptionKey
 	var share share
 
 	for _, chunk := range chunks {
@@ -148,8 +148,8 @@ func (c *Client) parseBlob(r io.Reader) ([]*Account, error) {
 		case chunkIDFromString("SHAR"):
 			share, err = parseShare(
 				bytes.NewReader(chunk.payload),
-				c.session.encryptionKey,
-				c.session.privateKey)
+				c.session.EncryptionKey,
+				c.session.PrivateKey)
 			if err != nil {
 				return nil, err
 			}
@@ -397,8 +397,8 @@ func (c *Client) getShare(ctx context.Context, shareName string) (share, error) 
 		if chunk.id == chunkIDFromString("SHAR") {
 			share, err := parseShare(
 				bytes.NewReader(chunk.payload),
-				c.session.encryptionKey,
-				c.session.privateKey)
+				c.session.EncryptionKey,
+				c.session.PrivateKey)
 			if err != nil {
 				return share, err
 			}

--- a/account.go
+++ b/account.go
@@ -124,7 +124,7 @@ func (c *Client) parseBlob(r io.Reader) ([]*Account, error) {
 	}
 
 	accts := make([]*Account, 0)
-	key := c.encryptionKey
+	key := c.session.encryptionKey
 	var share share
 
 	for _, chunk := range chunks {
@@ -146,7 +146,10 @@ func (c *Client) parseBlob(r io.Reader) ([]*Account, error) {
 			accts = append(accts, acct)
 
 		case chunkIDFromString("SHAR"):
-			share, err = parseShare(bytes.NewReader(chunk.payload), c.encryptionKey, c.session.privateKey)
+			share, err = parseShare(
+				bytes.NewReader(chunk.payload),
+				c.session.encryptionKey,
+				c.session.privateKey)
 			if err != nil {
 				return nil, err
 			}
@@ -386,7 +389,10 @@ func (c *Client) getShare(ctx context.Context, shareName string) (share, error) 
 	}
 	for _, chunk := range chunks {
 		if chunk.id == chunkIDFromString("SHAR") {
-			share, err := parseShare(bytes.NewReader(chunk.payload), c.encryptionKey, c.session.privateKey)
+			share, err := parseShare(
+				bytes.NewReader(chunk.payload),
+				c.session.encryptionKey,
+				c.session.privateKey)
 			if err != nil {
 				return share, err
 			}

--- a/account.go
+++ b/account.go
@@ -118,7 +118,7 @@ func (c *Client) fetchBlob(ctx context.Context) ([]byte, error) {
 }
 
 func (c *Client) parseBlob(r io.Reader) ([]*Account, error) {
-	chunks, err := c.getCompleteChunks(r)
+	chunks, err := getCompleteChunks(r)
 	if err != nil {
 		return nil, err
 	}
@@ -160,7 +160,7 @@ func (c *Client) parseBlob(r io.Reader) ([]*Account, error) {
 	return accts, nil
 }
 
-func (c *Client) getCompleteChunks(r io.Reader) ([]*chunk, error) {
+func getCompleteChunks(r io.Reader) ([]*chunk, error) {
 	chunks, err := extractChunks(r)
 	if err != nil {
 		return nil, err
@@ -380,7 +380,7 @@ func (c *Client) getShare(ctx context.Context, shareName string) (share, error) 
 	if err != nil {
 		return share{}, err
 	}
-	chunks, err := c.getCompleteChunks(bytes.NewReader(blob))
+	chunks, err := getCompleteChunks(bytes.NewReader(blob))
 	if err != nil {
 		return share{}, err
 	}

--- a/account.go
+++ b/account.go
@@ -82,6 +82,12 @@ func (c *Client) Accounts(ctx context.Context) ([]*Account, error) {
 	return c.parseBlob(bytes.NewReader(blob))
 }
 
+// FetchEncryptedAccounts fetches the user's encrypted accounts from LastPass.
+// The returned []byte can be parsed using the ParseEncryptedAccounts method.
+func (c *Client) FetchEncryptedAccounts(ctx context.Context) ([]byte, error) {
+	return c.fetchBlob(ctx)
+}
+
 func (c *Client) fetchBlob(ctx context.Context) ([]byte, error) {
 	endpoint := c.baseURL + EndpointGetAccts
 	u, err := url.Parse(endpoint)
@@ -115,6 +121,13 @@ func (c *Client) fetchBlob(ctx context.Context) ([]byte, error) {
 		return nil, err
 	}
 	return decodeBase64(blobBase64)
+}
+
+// ParseEncryptedAccounts parses encrypted accounts into a []*Account.
+// The original encrypted accounts data can be obtained from LastPass
+// using the FetchEncryptedAccounts method.
+func (c *Client) ParseEncryptedAccounts(r io.Reader) ([]*Account, error) {
+	return c.parseBlob(r)
 }
 
 func (c *Client) parseBlob(r io.Reader) ([]*Account, error) {

--- a/client.go
+++ b/client.go
@@ -97,9 +97,11 @@ func NewClient(ctx context.Context, username, masterPassword string, opts ...Cli
 	if err = c.calculateTrustLabel(); err != nil {
 		return nil, err
 	}
-	if err = c.login(ctx, masterPassword, defaultPasswdIterations); err != nil {
+	currentSession, err := c.login(ctx, masterPassword, defaultPasswdIterations)
+	if err != nil {
 		return nil, err
 	}
+	c.session = currentSession
 	return c, nil
 }
 

--- a/client.go
+++ b/client.go
@@ -40,7 +40,6 @@ const (
 // Client represents a LastPass client.
 // A Client can be logged in to a single account at a given time.
 type Client struct {
-	user       string
 	httpClient *http.Client
 	session    *session
 	baseURL    string
@@ -74,7 +73,6 @@ func NewClient(ctx context.Context, username, masterPassword string, opts ...Cli
 		return nil, &AuthenticationError{"masterPassword must not be empty"}
 	}
 	c := &Client{
-		user:    username,
 		baseURL: "https://lastpass.com",
 	}
 	cookieJar, err := cookiejar.New(nil)
@@ -96,7 +94,7 @@ func NewClient(ctx context.Context, username, masterPassword string, opts ...Cli
 	if err = c.calculateTrustLabel(); err != nil {
 		return nil, err
 	}
-	currentSession, err := c.login(ctx, masterPassword, defaultPasswdIterations)
+	currentSession, err := c.login(ctx, username, masterPassword, defaultPasswdIterations)
 	if err != nil {
 		return nil, err
 	}

--- a/client.go
+++ b/client.go
@@ -40,17 +40,16 @@ const (
 // Client represents a LastPass client.
 // A Client can be logged in to a single account at a given time.
 type Client struct {
-	user          string
-	httpClient    *http.Client
-	encryptionKey []byte
-	session       *session
-	baseURL       string
-	otp           string
-	logger        Logger
-	configDir     string
-	trust         bool
-	trustID       string
-	trustLabel    string
+	user       string
+	httpClient *http.Client
+	session    *session
+	baseURL    string
+	otp        string
+	logger     Logger
+	configDir  string
+	trust      bool
+	trustID    string
+	trustLabel string
 }
 
 // ClientOption is the type of constructor options for NewClient(...).
@@ -288,7 +287,7 @@ func (c *Client) upsert(ctx context.Context, acct *Account) (result, error) {
 		return response.Result, &AuthenticationError{"client not logged in"}
 	}
 
-	key := c.encryptionKey
+	key := c.session.encryptionKey
 	share := share{}
 	if acct.isShared() {
 		share, err = c.getShare(ctx, acct.Share)

--- a/client.go
+++ b/client.go
@@ -33,6 +33,10 @@ const (
 	allowedCharsInTrustID = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890!@#$"
 )
 
+const (
+	defaultPasswdIterations = 100100
+)
+
 // Client represents a LastPass client.
 // A Client can be logged in to a single account at a given time.
 type Client struct {
@@ -93,7 +97,7 @@ func NewClient(ctx context.Context, username, masterPassword string, opts ...Cli
 	if err = c.calculateTrustLabel(); err != nil {
 		return nil, err
 	}
-	if err = c.login(ctx, masterPassword); err != nil {
+	if err = c.login(ctx, masterPassword, defaultPasswdIterations); err != nil {
 		return nil, err
 	}
 	return c, nil

--- a/encoding.go
+++ b/encoding.go
@@ -189,6 +189,8 @@ func decryptPrivateKey(privateKeyEncrypted string, encryptionKey []byte) (*rsa.P
 	if privateKeyEncrypted == "" {
 		// Key pair is not yet created. This happens for example when the account got created via
 		// https://lastpass.com/create-account.php but the user has never logged in.
+		// https://support.lastpass.com/help/
+		// why-am-i-seeing-an-error-no-private-key-cannot-decrypt-pending-shares-message-lp010147
 		return nil, nil
 	}
 

--- a/session.go
+++ b/session.go
@@ -27,6 +27,7 @@ type session struct {
 	// before being sent to LastPass servers.
 	passwdIterations int
 	token            string
+	encryptionKey    []byte
 	// user's private key for decrypting sharing keys (encryption keys of shared folders)
 	privateKey *rsa.PrivateKey
 }
@@ -131,16 +132,15 @@ func (c *Client) login(ctx context.Context, password string, passwdIterations in
 		}
 	}
 
-	privateKey, err := decryptPrivateKey(rsp.PrivateKeyEncrypted, c.encryptionKey)
+	privateKey, err := decryptPrivateKey(rsp.PrivateKeyEncrypted, encKey)
 	if err != nil {
 		return nil, err
 	}
 
-	c.encryptionKey = encKey
-
 	return &session{
 		passwdIterations: passwdIterations,
 		token:            rsp.Token,
+		encryptionKey:    encKey,
 		privateKey:       privateKey,
 	}, nil
 }

--- a/session.go
+++ b/session.go
@@ -32,13 +32,13 @@ type session struct {
 	privateKey *rsa.PrivateKey
 }
 
-func (c *Client) login(ctx context.Context, password string, passwdIterations int) (*session, error) {
-	loginHash, encKey := loginHashAndEncKey(c.user, password, passwdIterations)
+func (c *Client) login(ctx context.Context, user string, passwd string, passwdIterations int) (*session, error) {
+	loginHash, encKey := loginHashAndEncKey(user, passwd, passwdIterations)
 
 	form := url.Values{
 		"method":               []string{"cli"},
 		"xml":                  []string{"1"},
-		"username":             []string{c.user},
+		"username":             []string{user},
 		"hash":                 []string{loginHash},
 		"iterations":           []string{fmt.Sprint(passwdIterations)},
 		"includeprivatekeyenc": []string{"1"},
@@ -86,7 +86,7 @@ func (c *Client) login(ctx context.Context, password string, passwdIterations in
 		}
 		c.log(ctx, "failed to login with %d password iterations, re-trying with %d password iterations...",
 			passwdIterations, iterations)
-		return c.login(ctx, password, iterations)
+		return c.login(ctx, user, passwd, iterations)
 	}
 
 	const outOfBandRequired = "outofbandrequired"

--- a/session.go
+++ b/session.go
@@ -19,8 +19,7 @@ import (
 // This increases the user's time to approve the out-of-band (2nd) factor
 // (e.g. approving a push notification sent to their mobile phone).
 const (
-	MaxLoginRetries         = 7
-	defaultPasswdIterations = 100100
+	MaxLoginRetries = 7
 )
 
 type session struct {
@@ -32,10 +31,10 @@ type session struct {
 	privateKey *rsa.PrivateKey
 }
 
-func (c *Client) login(ctx context.Context, password string) error {
+func (c *Client) login(ctx context.Context, password string, passwdIterations int) error {
 	if c.session == nil {
 		c.session = &session{
-			passwdIterations: defaultPasswdIterations,
+			passwdIterations: passwdIterations,
 		}
 	}
 
@@ -94,7 +93,7 @@ func (c *Client) login(ctx context.Context, password string) error {
 		c.log(ctx, "failed to login with %d password iterations, re-trying with %d password iterations...",
 			c.session.passwdIterations, iterations)
 		c.session.passwdIterations = iterations
-		return c.login(ctx, password)
+		return c.login(ctx, password, iterations)
 	}
 
 	const outOfBandRequired = "outofbandrequired"

--- a/session.go
+++ b/session.go
@@ -22,17 +22,21 @@ const (
 	MaxLoginRetries = 7
 )
 
-type session struct {
-	// passwdIterations controls how many times password is hashed using PBKDF2
-	// before being sent to LastPass servers.
-	passwdIterations int
-	token            string
-	encryptionKey    []byte
-	// user's private key for decrypting sharing keys (encryption keys of shared folders)
-	privateKey *rsa.PrivateKey
+type Session struct {
+	// PasswdIterations controls how many times the user's password
+	// is hashed using PBKDF2 before being sent to LastPass.
+	PasswdIterations int
+
+	Token string
+
+	EncryptionKey []byte
+
+	// User's private key for decrypting sharing keys (encryption keys
+	// of shared folders).
+	PrivateKey *rsa.PrivateKey
 }
 
-func (c *Client) login(ctx context.Context, user string, passwd string, passwdIterations int) (*session, error) {
+func (c *Client) login(ctx context.Context, user string, passwd string, passwdIterations int) (*Session, error) {
 	loginHash, encKey := loginHashAndEncKey(user, passwd, passwdIterations)
 
 	form := url.Values{
@@ -137,11 +141,11 @@ func (c *Client) login(ctx context.Context, user string, passwd string, passwdIt
 		return nil, err
 	}
 
-	return &session{
-		passwdIterations: passwdIterations,
-		token:            rsp.Token,
-		encryptionKey:    encKey,
-		privateKey:       privateKey,
+	return &Session{
+		PasswdIterations: passwdIterations,
+		Token:            rsp.Token,
+		EncryptionKey:    encKey,
+		PrivateKey:       privateKey,
 	}, nil
 }
 

--- a/session.go
+++ b/session.go
@@ -27,8 +27,12 @@ type Session struct {
 	// is hashed using PBKDF2 before being sent to LastPass.
 	PasswdIterations int
 
+	// Token is the session token returned by LastPass during
+	// the login process.
 	Token string
 
+	// EncryptionKey is derived by hashing the user's password
+	// using PBKDF2.
 	EncryptionKey []byte
 
 	// User's private key for decrypting sharing keys (encryption keys

--- a/session.go
+++ b/session.go
@@ -35,9 +35,11 @@ type Session struct {
 	// using PBKDF2.
 	EncryptionKey []byte
 
-	// User's private key for decrypting sharing keys (encryption keys
-	// of shared folders).
-	PrivateKey *rsa.PrivateKey
+	// OptSharingKey is the user's private key for decrypting sharing
+	// keys. This is used for encryption keys of shared folders.
+	//
+	// This is nil if the user has not generated a sharing key.
+	OptSharingKey *rsa.PrivateKey
 }
 
 func (c *Client) login(ctx context.Context, user string, passwd string, passwdIterations int) (*Session, error) {
@@ -140,7 +142,7 @@ func (c *Client) login(ctx context.Context, user string, passwd string, passwdIt
 		}
 	}
 
-	privateKey, err := decryptPrivateKey(rsp.PrivateKeyEncrypted, encKey)
+	optPrivateKey, err := decryptPrivateKey(rsp.PrivateKeyEncrypted, encKey)
 	if err != nil {
 		return nil, err
 	}
@@ -149,7 +151,7 @@ func (c *Client) login(ctx context.Context, user string, passwd string, passwdIt
 		PasswdIterations: passwdIterations,
 		Token:            rsp.Token,
 		EncryptionKey:    encKey,
-		PrivateKey:       privateKey,
+		OptSharingKey:    optPrivateKey,
 	}, nil
 }
 


### PR DESCRIPTION
This set of changes refactors `Client`-related code to support
offline functionality.

This is accomplished by allowing callers to obtain and supply
data that is ordinarily provided by LastPass' networked service.
The goal of these changes is to enable an implementation of
the LastPass CLI, which can function completely offline if it has
an existing copy of the user's encrypted accounts and other
encrypted data derived from the user's master password.

The following public APIs have been added:

- `NewClientFromSession` - Function that returns a new `*Client` based
  a provided `Session` object
- `WithHTTPClient` - A `ClientOption` that allows users to specify their own
  HTTP client implementation
- `HTTPClient` - An interface that abstracts the Go http.Client.Do method
- `Client.Session` - A method that returns the current `Session` object
- `Session` - The original `session` struct, but now public and representative
  of session-specific data (mainly, the `EncryptionKey` field)
- `Client.FetchEncryptedAccounts` - A method that permits callers to obtain
  their encrypted accounts from LastPass
- `Client.ParseEncryptedAccounts` - A method that allows callers to parse
  the encrypted accounts returned by `FetchEncryptedAccounts`

In the process of implementing these changes, I tried to de-clutter some
of the internal functions. There are probably more changes than really
needed, but it helped me better understand the various relationships
between things in the code.